### PR TITLE
README.md: Check only *.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ journalctl -f | grep --line-buffered nostr_rs_relay | cut -d' ' -f 10,12-100
 #### Nginx logs
 
 ``` bash
-tail -f /var/log/nginx/*
+tail -f /var/log/nginx/*.log
 ```
 
 You can fire up a **tmux** session if you don't want to start multiple consoles


### PR DESCRIPTION
Check only log files as there may be gz files created by logrotate.